### PR TITLE
Fix rgb-matrix installation script URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This will take a while on a fresh device as it picks up all its updates.
 
 ```
 cd /home/pi
-curl https://raw.githubusercontent.com/adafruit/Raspberry-Pi-Installer-Scripts/main/rgb-matrix.sh > /tmp/rgb-matrix.sh
+curl https://raw.githubusercontent.com/adafruit/Raspberry-Pi-Installer-Scripts/refs/heads/main/converted_shell_scripts/rgb-matrix.sh > /tmp/rgb-matrix.sh
 sudo bash /tmp/rgb-matrix.sh
 ```
 


### PR DESCRIPTION
Updated the URL for downloading the rgb-matrix installation script.

The new .sh file is located here -> https://raw.githubusercontent.com/adafruit/Raspberry-Pi-Installer-Scripts/refs/heads/main/converted_shell_scripts/rgb-matrix.sh

Issue #39