### PR TITLE
Add max altitude variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ WEATHER_LOCATION = "Glasgow"
 OPENWEATHER_API_KEY = "" # Get an API key from https://openweathermap.org/price
 TEMPERATURE_UNITS = "metric"
 MIN_ALTITUDE = 100
+MAX_ALTITUDE = 30000
 BRIGHTNESS = 50
 GPIO_SLOWDOWN = 2
 JOURNEY_CODE_SELECTED = "GLA"
@@ -139,6 +140,7 @@ In reality you'll want to customise `config.py` for your own purposes.
 | `OPENWEATHER_API_KEY`    | If provided, enables OpenWeather API. [Get a free key here](https://openweathermap.org/price). *(Optional)* |
 | `TEMPERATURE_UNITS`      | One of `"metric"` or `"imperial"`. Defaults to `"metric"`. |
 | `MIN_ALTITUDE`           | Removes planes below this altitude (in feet). Useful for filtering out planes on the tarmac. |
+| `MAX_ALTITUDE`           | Removes planes above this altitude (in feet). Useful for reducing plane noise if location close to a flight path  |
 | `BRIGHTNESS`             | Range 0–100. Adjusts brightness of the display. |
 | `GPIO_SLOWDOWN`          | Range 0–4. Higher values help reduce flickering on faster hardware (e.g., `2` for Pi Zero 2 W). |
 | `JOURNEY_CODE_SELECTED`  | Three-letter airport code of a local airport to display in **bold**. *(Optional)* |

--- a/utilities/overhead_fr24.py
+++ b/utilities/overhead_fr24.py
@@ -8,15 +8,15 @@ from requests.exceptions import RequestException, ConnectionError
 from urllib3.exceptions import NewConnectionError, MaxRetryError
 
 try:
-    from config import MIN_ALTITUDE
+    from config import MIN_ALTITUDE, MAX_ALTITUDE
 except (ModuleNotFoundError, NameError, ImportError):
     MIN_ALTITUDE = 0  # feet
+    MAX_ALTITUDE = 10000  # feet
 
 
 RETRIES = 3
 RATE_LIMIT_DELAY = 1
 MAX_FLIGHT_LOOKUP = 5
-MAX_ALTITUDE = 10000  # feet
 EARTH_RADIUS_KM = 6371
 BLANK_FIELDS = ["", "N/A", "NONE"]
 

--- a/utilities/overhead_tar1090.py
+++ b/utilities/overhead_tar1090.py
@@ -7,9 +7,10 @@ from time import time
 from requests.exceptions import RequestException
 
 try:
-    from config import MIN_ALTITUDE
+    from config import MIN_ALTITUDE, MAX_ALTITUDE
 except (ModuleNotFoundError, NameError, ImportError):
     MIN_ALTITUDE = 0  # feet
+    MAX_ALTITUDE = 10000 # feet
 
 try:
     from config import ZONE_HOME, LOCATION_HOME
@@ -28,7 +29,6 @@ except (ModuleNotFoundError, NameError, ImportError):
 
 ROUTE_CACHE_TTL = 28800  # 8 hours
 MAX_FLIGHT_LOOKUP = 5
-MAX_ALTITUDE = 10000  # feet
 EARTH_RADIUS_KM = 6371
 BLANK_FIELDS = ["", "N/A", "NONE"]
 


### PR DESCRIPTION
Updated README, and two utilities files, to add a new variable -> MAX_ALTITUDE. This variable is defined in the config file (as per the README) and is captured in the except handling (as per the pattern with MIN_ALT..) 

This change allows people living with flights above home at +10,000ft, to change this setting in the file without changing the utilities files, and to capture flights overhead.

Solves Issue #41 