### PR TITLE
Fix .service template to allow pi user to copy manually

### DIFF
--- a/assets/FlightTracker.service
+++ b/assets/FlightTracker.service
@@ -6,12 +6,12 @@ Wants=network-online.target
 [Service]
 Type=simple
 ExecStartPre=/bin/sleep 20
-ExecStart=__HOME__/FlightTracker/env/bin/python __HOME__/FlightTracker/flight-tracker.py
-WorkingDirectory=__HOME__/FlightTracker
-StandardOutput=append:__HOME__/plane.log
-StandardError=append:__HOME__/plane.log
+ExecStart=/home/pi/FlightTracker/env/bin/python /home/pi/FlightTracker/flight-tracker.py
+WorkingDirectory=/home/pi/FlightTracker
+StandardOutput=append:/home/pi/plane.log
+StandardError=append:/home/pi/plane.log
 Restart=on-failure
-User=__USER__
+User=pi
 Environment=PYTHONUNBUFFERED=1
 Nice=-10
 IOSchedulingClass=realtime

--- a/platforms/pi/install.sh
+++ b/platforms/pi/install.sh
@@ -558,10 +558,9 @@ if [ ! -f "$SERVICE_TEMPLATE" ]; then
 fi
 
 info "Generating service file from template..."
-# Substitute __USER__ and __HOME__ placeholders
+# Substitute pi placeholder
 GENERATED_SERVICE="/tmp/FlightTracker.service"
-sed -e "s|__USER__|${CURRENT_USER}|g" \
-    -e "s|__HOME__|${CURRENT_HOME}|g" \
+sed -e "s|pi|${CURRENT_USER}|g" \
     "$SERVICE_TEMPLATE" > "$GENERATED_SERVICE"
 
 info "Installing systemd service..."

--- a/platforms/pi5/install.sh
+++ b/platforms/pi5/install.sh
@@ -374,9 +374,9 @@ if [ ! -f "$SERVICE_TEMPLATE" ]; then
 fi
 
 info "Generating service file from template..."
+# Substitute pi placeholder
 GENERATED_SERVICE="/tmp/FlightTracker.service"
-sed -e "s|__USER__|${CURRENT_USER}|g" \
-    -e "s|__HOME__|${CURRENT_HOME}|g" \
+sed -e "s|pi|${CURRENT_USER}|g" \
     "$SERVICE_TEMPLATE" > "$GENERATED_SERVICE"
 
 info "Installing systemd service..."


### PR DESCRIPTION
With the recent changes to FlightTracker.service, it is no longer possible to copy the .service file directly as per the following instructions: https://github.com/ColinWaddell/FlightTracker/blob/main/platforms/pi/INSTALL.md#running-on-boot-systemd

This fix modifies the .service template to be valid for the default pi user (more advanced users probably know how to edit the file) and adjusts the auto install scripts accordingly.