### PR TITLE
Update INSTALL.md from https://learn.adafruit.com/adafruit-rgb-matrix-bonnet-for-raspberry-pi/install-using-script

### DIFF
--- a/platforms/pi/INSTALL.md
+++ b/platforms/pi/INSTALL.md
@@ -60,8 +60,10 @@ sudo apt-get dist-upgrade
 
 ```bash
 cd /home/pi
-curl https://raw.githubusercontent.com/adafruit/Raspberry-Pi-Installer-Scripts/main/rgb-matrix.sh > /tmp/rgb-matrix.sh
-sudo bash /tmp/rgb-matrix.sh
+sudo apt install -y wget
+pip3 install adafruit-python-shell
+wget https://github.com/adafruit/Raspberry-Pi-Installer-Scripts/raw/main/rgb-matrix.py
+sudo -E env PATH=$PATH python3 rgb-matrix.py
 ```
 
 Verify with the demo:


### PR DESCRIPTION
updated install instructions for rgb-matrix

# Pull Request

## Summary
<!-- Brief description of what this PR does -->

## Motivation
Automated scripts for rgb-matrix were failing, went to the manual install and eventually back to the source to find updated instructions

## Changes
<!-- Key changes made -->

## Hardware Tested On
<!-- Specify the Raspberry Pi model(s) this was tested on and how it was tested (steps, etc) -->
- **Raspberry Pi model:** <!-- e.g. Pi 4B 8GB, Pi 5 4GB, Pi 3B+, Pi Zero 2 W -->
- **OS:** <!-- e.g. Raspberry Pi OS Bookworm 64-bit, Debian 12, DietPi -->
- **Testing Steps:** <!-- The steps taken to ensure this was tested thoroughly -->

## Checklist
- [ ] Tests pass
- [ ] Linter passes
- [ ] Documentation updated
- [ ] No secrets committed
- [ ] Tested on actual hardware