### PR TITLE
fix: accept dump1090 field names in tar1090 parser

### DIFF
--- a/tests/test_overhead.py
+++ b/tests/test_overhead.py
@@ -207,6 +207,97 @@ class TestTar1090DataUnavailability:
         assert overhead_instance.data[0].callsign == "BAW123"
         assert overhead_instance.data[0].altitude == 35000
 
+    def test_dump1090_field_names(self, overhead_instance):
+        """tar1090/dump1090 forks may use altitude/speed/vert_rate instead of
+        alt_baro/gs/baro_rate.  Ensure the parser handles both field names."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "aircraft": [
+                {
+                    "hex": "485779",
+                    "flight": "KLM1127 ",
+                    "lat": 55.5,
+                    "lon": -4.0,
+                    "altitude": 34000,   # dump1090 name (no alt_baro)
+                    "speed": 415,         # dump1090 name (no gs)
+                    "vert_rate": 64,      # dump1090 name (no baro_rate)
+                    "track": 277,
+                    # no "desc" field — common when --db-file-lt isn't set
+                }
+            ]
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        mock_route = RouteInfo(
+            origin="AMS",
+            destination="GLA",
+            plane="Boeing 737",
+            origin_name="Amsterdam Schiphol",
+            origin_municipality="Amsterdam",
+            origin_country="Netherlands",
+            destination_name="Glasgow Airport",
+            destination_municipality="Glasgow",
+            destination_country="United Kingdom",
+        )
+
+        overhead_instance._session.get = MagicMock(return_value=mock_response)
+
+        with patch(
+            "utilities.overhead_tar1090.route_lookup.get_route", return_value=mock_route
+        ):
+            overhead_instance.refresh()
+
+        assert overhead_instance.error is None
+        assert overhead_instance.data_is_empty is False
+        assert len(overhead_instance.data) == 1
+        flight = overhead_instance.data[0]
+        assert flight.callsign == "KLM1127"
+        assert flight.altitude == 34000
+        assert flight.ground_speed == 415
+        assert flight.vertical_speed == 64
+
+    def test_mixed_field_names(self, overhead_instance):
+        """A mix of readsb and dump1090 field names in the same feed should work."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "aircraft": [
+                {
+                    "hex": "408134",
+                    "flight": "BAW506 ",
+                    "lat": 55.5,
+                    "lon": -4.0,
+                    "alt_baro": 14025,   # readsb name
+                    "gs": 388,            # readsb name
+                    "baro_rate": 2624,    # readsb name
+                    "track": 221,
+                    "desc": "A320",
+                },
+                {
+                    "hex": "a3728a",
+                    "flight": "N321FF ",
+                    "lat": 55.6,
+                    "lon": -3.9,
+                    "altitude": 4050,    # dump1090 name
+                    "speed": 143,        # dump1090 name
+                    "vert_rate": 0,      # dump1090 name
+                    "track": 217,
+                },
+            ]
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        mock_route = RouteInfo()
+
+        overhead_instance._session.get = MagicMock(return_value=mock_response)
+
+        with patch(
+            "utilities.overhead_tar1090.route_lookup.get_route", return_value=mock_route
+        ):
+            overhead_instance.refresh()
+
+        assert overhead_instance.error is None
+        assert len(overhead_instance.data) == 2
+
 
 # ---------------------------------------------------------------------------
 # FR24 helpers

--- a/utilities/overhead_tar1090.py
+++ b/utilities/overhead_tar1090.py
@@ -104,11 +104,16 @@ class Overhead:
             zone = self.zone_home
             home = self.location_home
 
+            # readsb/tar1090 uses alt_baro, gs, baro_rate, desc
+            # dump1090 (and older forks) uses altitude, speed, vert_rate
+            # Accept either field name so the parser works with both.
             candidates = []
             for ac in aircraft_list:
                 lat = ac.get("lat")
                 lon = ac.get("lon")
                 alt = ac.get("alt_baro")
+                if alt is None:
+                    alt = ac.get("altitude")
 
                 if lat is None or lon is None:
                     continue
@@ -123,7 +128,8 @@ class Overhead:
 
             candidates.sort(
                 key=lambda ac: distance_from_home(
-                    ac["lat"], ac["lon"], ac["alt_baro"], home
+                    ac["lat"], ac["lon"],
+                    ac.get("alt_baro") or ac.get("altitude"), home
                 )
             )
 
@@ -132,8 +138,9 @@ class Overhead:
                     callsign = clean_field(ac.get("flight"))
 
                     # tar1090 provides aircraft type directly from its local DB
-                    # (tar1090-db enrichment). We keep this as the primary source
-                    # since it's local and instant. hexdb may fill it in if blank.
+                    # (tar1090-db enrichment, requires --db-file-lt flag). We keep
+                    # this as the primary source since it's local and instant.
+                    # hexdb may fill it in if blank.
                     plane = clean_field(ac.get("desc"))
 
                     # mode_s (hex) enables the hexdb aircraft endpoint which
@@ -147,7 +154,7 @@ class Overhead:
                     lat = ac.get("lat")
                     lng = ac.get("lon")
                     try:
-                        gs_knots = float(ac.get("gs", 0) or 0)
+                        gs_knots = float(ac.get("gs") or ac.get("speed") or 0)
                     except (TypeError, ValueError):
                         gs_knots = 0.0
                     ground_speed_mps = gs_knots * 0.514444
@@ -176,7 +183,7 @@ class Overhead:
 
                     # Telemetry
                     try:
-                        ground_speed = int(ac.get("gs", 0) or 0)
+                        ground_speed = int(ac.get("gs") or ac.get("speed") or 0)
                     except (TypeError, ValueError):
                         ground_speed = 0
 
@@ -191,13 +198,14 @@ class Overhead:
                             plane=plane,
                             callsign=display_callsign,
                             icao_callsign=icao_callsign,
-                            altitude=ac.get("alt_baro", 0),
+                            altitude=ac.get("alt_baro") or ac.get("altitude") or 0,
                             ground_speed=ground_speed,
                             heading=heading,
-                            # baro_rate may be None when the transponder doesn't
-                            # report vertical rate; default to 0 to keep the
-                            # Flight.vertical_speed field an int, not None.
-                            vertical_speed=ac.get("baro_rate") or 0,
+                            # baro_rate/vert_rate may be None when the
+                            # transponder doesn't report vertical rate;
+                            # default to 0 to keep the Flight.vertical_speed
+                            # field an int, not None.
+                            vertical_speed=ac.get("baro_rate") or ac.get("vert_rate") or 0,
                         )
                     )
 


### PR DESCRIPTION
The tar1090 parser expected readsb-style field names (alt_baro, gs, baro_rate, desc) but some tar1090/dump1090 forks output dump1090-style names (altitude, speed, vert_rate). The critical mismatch was alt_baro vs altitude — every aircraft was filtered out because ac.get('alt_baro') returned None, failing the isinstance check.

Now accepts either field name:
  alt_baro OR altitude  (barometric altitude)
  gs OR speed            (ground speed in knots)
  baro_rate OR vert_rate (vertical rate in ft/min)

The desc field (aircraft type from tar1090-db) remains optional — it requires the --db-file-lt flag in readsb and is absent in many setups. hexdb fallback already handles missing aircraft types.

Added tests for dump1090 field names and mixed readsb/dump1090 feeds.

Fixes user report: tar1090 data source showing no flights.

# Pull Request

## Summary
<!-- Brief description of what this PR does -->

## Motivation
<!-- Why is this change needed? -->

## Changes
<!-- Key changes made -->

## Hardware Tested On
<!-- Specify the Raspberry Pi model(s) this was tested on and how it was tested (steps, etc) -->
- **Raspberry Pi model:** <!-- e.g. Pi 4B 8GB, Pi 5 4GB, Pi 3B+, Pi Zero 2 W -->
- **OS:** <!-- e.g. Raspberry Pi OS Bookworm 64-bit, Debian 12, DietPi -->
- **Testing Steps:** <!-- The steps taken to ensure this was tested thoroughly -->

## Checklist
- [ ] Tests pass
- [ ] Linter passes
- [ ] Documentation updated
- [ ] No secrets committed
- [ ] Tested on actual hardware